### PR TITLE
Remove all channels from the `conda` configuration files except and only keep `conda-forge`

### DIFF
--- a/chimp_smhi_v0.yml
+++ b/chimp_smhi_v0.yml
@@ -1,8 +1,6 @@
 name: chimp_smhi_v0
 channels:
-  - pytorch
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - pytorch

--- a/chimp_smhi_v1.yml
+++ b/chimp_smhi_v1.yml
@@ -1,8 +1,6 @@
 name: chimp_smhi_v1
 channels:
-  - pytorch
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - pytorch

--- a/chimp_smhi_v2.yml
+++ b/chimp_smhi_v2.yml
@@ -1,8 +1,6 @@
 name: chimp_smhi_v2
 channels:
-  - pytorch
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - pytorch

--- a/chimp_smhi_v3.yml
+++ b/chimp_smhi_v3.yml
@@ -1,8 +1,6 @@
 name: chimp_smhi_v3
 channels:
-  - pytorch
   - conda-forge
-  - defaults
 dependencies:
   - python=3.10
   - pytorch


### PR DESCRIPTION
We would like to only have the `conda-forge` in the channels.

Note that in general, we rely on our `.condarc` file made alongside `micromamba` as a part of the `base` container image, in which we explicitly set the channel to `conda-forge` only.
